### PR TITLE
Fix checkbox not entering read-only state when restoring default options

### DIFF
--- a/guirelated.cpp
+++ b/guirelated.cpp
@@ -1198,6 +1198,9 @@ VOID UpdateOptionsDialogControls(CONST HWND hDlg, CONST BOOL bUpdateAll, CONST P
     CheckDlgButton(hDlg, IDC_RADIO_HEX_UPPERCASE, pprogram_options->iHexFormat == UPPERCASE ? BST_CHECKED : BST_UNCHECKED);
     CheckDlgButton(hDlg, IDC_RADIO_HEX_LOWERCASE, pprogram_options->iHexFormat == LOWERCASE ? BST_CHECKED : BST_UNCHECKED);
 
+	// make "New window from explorer" read‑only when Job Queueing is disabled
+	EnableWindow(GetDlgItem(hDlg, IDC_ALWAYS_USE_NEW_WINDOW), pprogram_options->bEnableQueue);
+
     dlgItem = GetDlgItem(hDlg,IDC_UNICODE_TYPE);
     for(int i=0;i<ComboBox_GetCount(dlgItem);i++) {
         if(ComboBox_GetItemData(dlgItem,i)==pprogram_options->iUnicodeSaveType)


### PR DESCRIPTION
### Summary
When pressing the **Defaults** button in the Options dialog, the checkbox **“New window from explorer”** is reset to an unchecked state but remains enabled. This is incorrect, because the control should enter a read-only state whenever **“Enable Job Queueing”** is not active. The behaviour is inconsistent with the rest of the dialog logic, where the read-only state of this checkbox is supposed to follow the value of the queueing option.

### Current behaviour
- The checkbox is correctly reset to an unchecked state after clicking Defaults.
- The checkbox incorrectly remains enabled and can still be modified.

### Expected behaviour
- The checkbox should also become read-only, as “Enable Job Queueing” is off.

### Cause
The issue comes from `UpdateOptionsDialogControls`, which synchronises the dialog controls with the program state but did not update the read-only state of the “New window from explorer” checkbox based on the value of **“Enable Job Queueing”**.

### Fix
The missing `EnableWindow()` call has been added to `guirelated.cpp`, so the read-only state of the checkbox is now updated according to **“Enable Job Queueing”** when the dialog controls are refreshed (including after pressing Defaults).

For reference, a similar `EnableWindow()` call already exists [in `dlgproc.cpp` at line 607](https://github.com/OV2/RapidCRC-Unicode/blob/c7e26e876bf4d0ca582cfc37a961a4957313aa1d/dlgproc.cpp#L607), which updates the same checkbox based on the queueing option. The fix in this PR brings `UpdateOptionsDialogControls` in line with that behaviour.

### Result
The UI now behaves consistently across all code paths, and the state of the checkbox always reflects the value of **“Enable Job Queueing”** after restoring default options.