### PR TITLE
Remove redundant checkbox state update in DlgProcOptions

### DIFF
--- a/dlgproc.cpp
+++ b/dlgproc.cpp
@@ -510,7 +510,6 @@ INT_PTR CALLBACK DlgProcOptions(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 		UpdateOptionsDialogControls(hDlg, TRUE, & program_options_temp);
 
 		EnableWindow(GetDlgItem(hDlg,IDC_ENABLE_QUEUE),g_pstatus.bHaveComCtrlv6);
-		EnableWindow(GetDlgItem(hDlg, IDC_ALWAYS_USE_NEW_WINDOW), program_options_temp.bEnableQueue);
 
 		return TRUE;
 

--- a/dlgproc.cpp
+++ b/dlgproc.cpp
@@ -603,6 +603,7 @@ INT_PTR CALLBACK DlgProcOptions(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 		case IDC_ENABLE_QUEUE:
 			if(HIWORD(wParam) == BN_CLICKED){
 				program_options_temp.bEnableQueue = (IsDlgButtonChecked(hDlg, IDC_ENABLE_QUEUE) == BST_CHECKED);
+				// make "New window from explorer" read-only when Job Queueing is disabled
 				EnableWindow(GetDlgItem(hDlg, IDC_ALWAYS_USE_NEW_WINDOW), program_options_temp.bEnableQueue);
 				return TRUE;
 			}

--- a/guirelated.cpp
+++ b/guirelated.cpp
@@ -1198,7 +1198,7 @@ VOID UpdateOptionsDialogControls(CONST HWND hDlg, CONST BOOL bUpdateAll, CONST P
     CheckDlgButton(hDlg, IDC_RADIO_HEX_UPPERCASE, pprogram_options->iHexFormat == UPPERCASE ? BST_CHECKED : BST_UNCHECKED);
     CheckDlgButton(hDlg, IDC_RADIO_HEX_LOWERCASE, pprogram_options->iHexFormat == LOWERCASE ? BST_CHECKED : BST_UNCHECKED);
 
-	// make "New window from explorer" read‑only when Job Queueing is disabled
+	// make "New window from explorer" read-only when Job Queueing is disabled
 	EnableWindow(GetDlgItem(hDlg, IDC_ALWAYS_USE_NEW_WINDOW), pprogram_options->bEnableQueue);
 
     dlgItem = GetDlgItem(hDlg,IDC_UNICODE_TYPE);


### PR DESCRIPTION
This PR is a follow-up to #219.

### Code Cleanup

I have removed a line in `dlgproc.cpp` that became redundant. The instruction to update the read-only state of the "New window from explorer" checkbox is now centrally handled inside `UpdateOptionsDialogControls`. This ensures the UI remains consistent across all code paths where the dialog is refreshed, including the initial refresh when the dialog is opened.

### Analysis of Job Queueing and Legacy Constraints

I also reviewed the remaining line:

```c++
EnableWindow(GetDlgItem(hDlg,IDC_ENABLE_QUEUE),g_pstatus.bHaveComCtrlv6);
```

There is a theoretical edge case where the behavior could be incorrect: if the program is launched with "Job Queueing" enabled on a system lacking _Common Controls v6_. In this scenario, the checkbox would be greyed out (read-only) while remaining checked, and the "New window from explorer" option would incorrectly remain editable. In other words, for the expected behavior, we rely on the fact that "Job Queueing" should be disabled from the start.

However, this scenario only affects very legacy environments (pre-Windows XP). Since _Common Controls v6_ has been available for over two decades—and the program already requires a minimum of Windows NT for Unicode support—improving support for this specific edge case would complicate the code for no actual gain.

Furthermore, unlike the logic for the "New window from explorer" checkbox which depends on user-changeable options, the check for `bHaveComCtrlv6` is a static system property. It makes sense to keep this line in `WM_INITDIALOG` to avoid unnecessary redundant calls during every UI refresh. Therefore, leaving the line as-is is currently the best solution.

### Future Considerations

The ideal long-term fix would be to clean up all conditions based on `bHaveComCtrlv6` and simply assume it is available. Requiring Windows XP as a minimum seems perfectly reasonable today, especially for a Unicode-targeted application, and would allow for some code simplification by removing these obsolete checks.