### PR TITLE
Remove obsolete Common Controls v6 version check

### DIFF
--- a/dlgproc.cpp
+++ b/dlgproc.cpp
@@ -411,8 +411,7 @@ LRESULT CALLBACK WndProcMain(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPar
 					    //if the queueing option has been changed we need to clear the lists, since this also enables/disables grouping
 					    if(prevQueue!=g_program_options.bEnableQueue) {
 						    ClearAllItems(arrHwnd,&showresult_params);
-						    if(g_pstatus.bHaveComCtrlv6)
-							    ListView_EnableGroupView(arrHwnd[ID_LISTVIEW],g_program_options.bEnableQueue);
+						    ListView_EnableGroupView(arrHwnd[ID_LISTVIEW],g_program_options.bEnableQueue);
 					    }
 					    UpdateListViewColumns(arrHwnd, lAveCharWidth);
 				    }
@@ -508,8 +507,6 @@ INT_PTR CALLBACK DlgProcOptions(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 		CopyJustProgramOptions(& g_program_options, & program_options_temp);
 
 		UpdateOptionsDialogControls(hDlg, TRUE, & program_options_temp);
-
-		EnableWindow(GetDlgItem(hDlg,IDC_ENABLE_QUEUE),g_pstatus.bHaveComCtrlv6);
 
 		return TRUE;
 

--- a/globals.h
+++ b/globals.h
@@ -518,7 +518,6 @@ struct PROGRAM_OPTIONS {
 };
 
 typedef struct{
-	BOOL bHaveComCtrlv6;							//are the common controls v6 available? (os>=winxp)
     BOOL bIsVista;
 	BOOL bStartedWithClosableShellExtAction;
 }PROGRAM_STATUS;

--- a/guirelated.cpp
+++ b/guirelated.cpp
@@ -470,7 +470,7 @@ void RemoveItems(CONST HWND arrHwnd[ID_NUM_WINDOWS],list<FILEINFO*> *finalList)
 		pList->fInfos.remove_if(ComparePtr(pFileinfo));
 		if(pList->fInfos.empty()) {
 			doneList->remove(pList);
-			if(g_program_options.bEnableQueue && g_pstatus.bHaveComCtrlv6)
+			if(g_program_options.bEnableQueue)
 				ListView_RemoveGroup(arrHwnd[ID_LISTVIEW],pList->iGroupId);
 			delete pList;
 		}
@@ -667,20 +667,17 @@ BOOL InitListView(CONST HWND hWndListView, CONST LONG lACW)
 	//full row select
 	ListView_SetExtendedListViewStyle(hWndListView, LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFER);
 
-    //explorer-style listview and group view work only with common controls v6
-	if(g_pstatus.bHaveComCtrlv6) {
-		uxTheme = LoadLibrary(TEXT("uxtheme.dll"));
-		if(uxTheme) {
-			SetWindowTheme = (SWT) GetProcAddress(uxTheme,"SetWindowTheme");
-			if(SetWindowTheme != NULL) {
-				(SetWindowTheme)(hWndListView, L"Explorer", NULL);
-				(SetWindowTheme)(ListView_GetHeader(hWndListView), L"Explorer", NULL);
-			}
-			FreeLibrary(uxTheme);
+	uxTheme = LoadLibrary(TEXT("uxtheme.dll"));
+	if(uxTheme) {
+		SetWindowTheme = (SWT) GetProcAddress(uxTheme,"SetWindowTheme");
+		if(SetWindowTheme != NULL) {
+			(SetWindowTheme)(hWndListView, L"Explorer", NULL);
+			(SetWindowTheme)(ListView_GetHeader(hWndListView), L"Explorer", NULL);
 		}
-		if(g_program_options.bEnableQueue)
-			ListView_EnableGroupView(hWndListView,TRUE);
+		FreeLibrary(uxTheme);
 	}
+	if(g_program_options.bEnableQueue)
+		ListView_EnableGroupView(hWndListView,TRUE);
 
 	lvcolumn.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
 	lvcolumn.fmt = LVCFMT_LEFT;
@@ -800,7 +797,7 @@ BOOL InsertItemIntoList(CONST HWND hListView, FILEINFO * pFileinfo,lFILEINFO *fi
 	lvI.mask = LVIF_TEXT | LVIF_IMAGE | LVIF_PARAM | LVIF_STATE;
 	lvI.state = 0;
 	lvI.stateMask = 0;
-	if(g_program_options.bEnableQueue && g_pstatus.bHaveComCtrlv6) {
+	if(g_program_options.bEnableQueue) {
 		lvI.mask |= LVIF_GROUPID;
 		lvI.iGroupId = fileList->iGroupId;
 	}
@@ -1279,8 +1276,7 @@ VOID ClearAllItems(CONST HWND arrHwnd[ID_NUM_WINDOWS], SHOWRESULT_PARAMS * pshow
 	SyncQueue.clearQueue();
 	SyncQueue.clearList();
 	ListView_DeleteAllItems(arrHwnd[ID_LISTVIEW]);
-	if(g_pstatus.bHaveComCtrlv6)
-		ListView_RemoveAllGroups(arrHwnd[ID_LISTVIEW]);
+	ListView_RemoveAllGroups(arrHwnd[ID_LISTVIEW]);
 	ShowResult(arrHwnd,NULL,pshowresult_params);
 	DisplayStatusOverview(arrHwnd[ID_EDIT_STATUS]);
 }

--- a/helpfcts.cpp
+++ b/helpfcts.cpp
@@ -428,9 +428,6 @@ VOID ReadOptions()
 		CloseHandle(hFile);
 	}
 
-	if(!g_pstatus.bHaveComCtrlv6)
-		program_options_file.bEnableQueue = FALSE;
-
     // import old program options
     if(program_options_file.bCalcCrcPerDefault!=-1) {
         program_options_file.bCalcPerDefault[HASH_TYPE_CRC32] = program_options_file.bCalcCrcPerDefault;

--- a/threadprocs.cpp
+++ b/threadprocs.cpp
@@ -157,7 +157,7 @@ UINT __stdcall ThreadProc_Calc(VOID * pParam)
 
 		QueryPerformanceFrequency((LARGE_INTEGER*)&wqFreq);
 
-		if(g_program_options.bEnableQueue && g_pstatus.bHaveComCtrlv6) {
+		if(g_program_options.bEnableQueue) {
 			if(fileList->iGroupId==0)
 				InsertGroupIntoListView(arrHwnd[ID_LISTVIEW],fileList);
 			else

--- a/winmain.cpp
+++ b/winmain.cpp
@@ -197,7 +197,6 @@ INT WINAPI WinMain (HINSTANCE hInst, HINSTANCE /*hPrevInstance*/, LPSTR /*szCmdL
 
 	g_hInstance = hInst;
 
-    g_pstatus.bHaveComCtrlv6=CheckOsVersion(5,1);	//are the common controls v6 available? (os>=winxp)
     g_pstatus.bIsVista=CheckOsVersion(6,0);
 
 	InitializeCriticalSection(&thread_fileinfo_crit);


### PR DESCRIPTION
### Description

Following the discussion in #220, this PR removes the `bHaveComCtrlv6` flag and the associated `CheckOsVersion(5,1)` call.

As mentioned by @OV2 in [this comment](https://github.com/OV2/RapidCRC-Unicode/pull/220#issuecomment-4321749728), the project now uses the `v141_xp` toolset. This means the minimum supported operating system is already Windows XP, making any runtime check for Common Controls v6 redundant.

### Changes

- Removed `bHaveComCtrlv6` from the global status structure.
- Removed the OS version check during initialization.
- Simplified UI logic by removing conditional blocks that relied on this check, as Common Controls v6 is guaranteed to be available on Windows XP and later.