### PR TITLE
Optimize default read buffer size and implement validation constants

### DIFF
--- a/dlgproc.cpp
+++ b/dlgproc.cpp
@@ -570,8 +570,9 @@ INT_PTR CALLBACK DlgProcOptions(HWND hDlg, UINT message, WPARAM wParam, LPARAM l
 			if(HIWORD(wParam) == EN_CHANGE){
 				GetWindowText(GetDlgItem(hDlg, IDC_EDIT_READ_BUFFER_SIZE), szTemp, MAX_PATH_EX);
                 program_options_temp.uiReadBufferSizeKb =_ttoi(szTemp);
-                if(program_options_temp.uiReadBufferSizeKb < 1 || program_options_temp.uiReadBufferSizeKb > 20 * 1024)
-                    program_options_temp.uiReadBufferSizeKb = DEFAULT_BUFFER_SIZE_CALC;
+                if(program_options_temp.uiReadBufferSizeKb < MIN_BUFFER_SIZE_CALC ||
+                   program_options_temp.uiReadBufferSizeKb > MAX_BUFFER_SIZE_CALC)
+                        program_options_temp.uiReadBufferSizeKb = DEFAULT_BUFFER_SIZE_CALC;
 				return TRUE;
 			}
 			break;

--- a/globals.h
+++ b/globals.h
@@ -64,7 +64,9 @@ PCHAR* CommandLineToArgvA(PCHAR CmdLine, int* _argc);
 #define WM_THREAD_FILEINFO_START	(WM_USER + 9)
 
 // some sizes for variables
-#define DEFAULT_BUFFER_SIZE_CALC	(8 * 1024)
+#define DEFAULT_BUFFER_SIZE_CALC	512			// 512 KB - Optimal for L2 cache locality
+#define MIN_BUFFER_SIZE_CALC		1			// 1 KB
+#define MAX_BUFFER_SIZE_CALC		20480		// 20 MB safety limit
 #define MAX_BUFFER_SIZE_OFN 0xFFFFF // Win9x has a problem with values where just the first bit is set like 0x20000 for OFN buffer:
 #define MAX_PATH_EX 32767
 #define MAX_LINE_LENGTH MAX_PATH_EX + 100

--- a/helpfcts.cpp
+++ b/helpfcts.cpp
@@ -471,8 +471,9 @@ VOID ReadOptions()
 	   !IsLegalFilename(program_options_file.szFilenameSfv))
             program_options_file.SetDefaults();
 
-    if(program_options_file.uiReadBufferSizeKb < 1 || program_options_file.uiReadBufferSizeKb > 20 * 1024) // limit between 1kb and 20mb
-        program_options_file.uiReadBufferSizeKb = DEFAULT_BUFFER_SIZE_CALC;
+    if(program_options_file.uiReadBufferSizeKb < MIN_BUFFER_SIZE_CALC ||
+       program_options_file.uiReadBufferSizeKb > MAX_BUFFER_SIZE_CALC)
+            program_options_file.uiReadBufferSizeKb = DEFAULT_BUFFER_SIZE_CALC;
 
     g_program_options = program_options_file;
 


### PR DESCRIPTION
Following my comments on commit `154deb6` (see [details here](https://github.com/OV2/RapidCRC-Unicode/commit/154deb694640bcba967418b7abce6b7c1f3902f3#commitcomment-183490469)), this PR optimizes the default read buffer size for better CPU performance.

### Summary of Changes:
1. **Performance Optimization:** Reduced the default buffer size **from 8192 KB (8 MB) to 512 KB**. This change ensures the buffer fits within the L2 cache of current CPUs, improving data locality and reducing latency during hash calculations.
2. **Refactoring:** Introduced explicit `MIN_BUFFER_SIZE_CALC` and `MAX_BUFFER_SIZE_CALC` constants to replace **magic numbers** in the validation logic within `dlgproc.cpp` and `helpfcts.cpp`.

### Technical Justification:
The previous 8 MB default significantly exceeds the **L2 cache capacity** of contemporary processors, forcing the hashing thread to **fetch data from L3 and even RAM** (high latency). A 512 KB buffer size is more efficient because:
* **Improves Cache Locality:** It fits within the L2 cache of modern architectures (e.g., AMD Zen, Intel Core), significantly increasing throughput by keeping data closer to the execution units.
* **Reduces Pipeline Latency:** It decreases the startup lag for the producer-consumer model, which is especially noticeable when processing multiple medium-sized files.
* **Optimizes I/O:** Smaller buffers allow for smoother asynchronous swapping and reduced memory bus contention without sacrificing throughput on modern NVMe drives.